### PR TITLE
Fix dll loading for windows

### DIFF
--- a/lib/numo/openblas.rb
+++ b/lib/numo/openblas.rb
@@ -5,4 +5,11 @@ require 'numo/linalg/linalg'
 require 'numo/openblas/version'
 require 'numo/openblas/openblas'
 
-Numo::Linalg::Loader.load_openblas(File.expand_path("#{__dir__}/../../vendor/lib/"))
+case RUBY_PLATFORM
+when /mswin|msys|mingw|cygwin/
+  lib_dir = 'bin'
+else
+  lib_dir = 'lib'
+end
+
+Numo::Linalg::Loader.load_openblas(File.expand_path("#{__dir__}/../../vendor/#{lib_dir}/"))


### PR DESCRIPTION
In 'vendor/lib' directory there is no dll which used by windows. Dll file is in 'bin' directory so it tries to determine os and choose correct path.